### PR TITLE
Add functions for checking if EDD exists

### DIFF
--- a/edd-gateway-braintree.php
+++ b/edd-gateway-braintree.php
@@ -316,7 +316,11 @@ add_filter( 'edd_settings_sections_gateways', 'edd_braintree_add_settings_sectio
  * Migrates old settings values to the new keys
  */
 function edd_braintree_migrate_settings_ids() {
-
+	
+	if ( !edd_braintree_required_items_exist() ){
+		return false;	
+	}
+	
 	if ( edd_get_option( 'edd_braintree_ids_migrated', false ) ) {
 		return;
 	}
@@ -344,3 +348,64 @@ function edd_braintree_migrate_settings_ids() {
 	edd_update_option( 'edd_braintree_ids_migrated', true );
 }
 add_action( 'admin_init', 'edd_braintree_migrate_settings_ids' );
+
+/**
+ * Braintree check for required plugins and versions.
+ *
+ * This function is used to check if all required plugins are active and if their versions are properly up to date. If not, it will return false and add a notice to admin_notices.
+ *
+ * @since 1.1.4
+ * 
+ * @return bool
+ */
+function edd_braintree_required_items_exist(){
+		
+	global $wp_version;
+	
+	// If the WordPress site doesn't meet the correct EDD and WP version requirements, deactivate and show notice.
+	if ( version_compare( $wp_version, '4.2', '<' ) ) {
+		add_action( 'admin_notices', 'edd_braintree_wp_notice' );
+		return false;
+	} else if ( !class_exists( 'Easy_Digital_Downloads' ) || version_compare( EDD_VERSION, '2.4', '<' ) ) {
+		add_action( 'admin_notices', 'edd_braintree_edd_notice' );
+		return false;
+	}
+	
+	return true;
+}
+
+/**
+ * Braintree minimum EDD version notice
+ *
+ * This function is used to throw an admin notice when the WordPress install
+ * does not meet Braintree's minimum EDD version requirements.
+ *
+ * @since 1.1.4
+ * @access public
+ * 
+ * @return void
+ */
+function edd_braintree_edd_notice() { ?>
+	<div class="updated">
+		<p><?php printf( __( '<strong>Notice:</strong> Easy Digital Downloads Braintree requires Easy Digital Downloads 2.5 or higher in order to function properly.', 'edd_fes' ) ); ?></p>
+	</div>
+	<?php
+}
+
+/**
+ * Braintree minimum WP version notice
+ *
+ * This function is used to throw an admin notice when the WordPress install
+ * does not meet Braintree's minimum WP version requirements.
+ *
+ * @since 1.1.4
+ * @access public
+ * 
+ * @return void
+ */
+function edd_braintree_wp_notice() { ?>
+	<div class="updated">
+		<p><?php printf( __( '<strong>Notice:</strong> Easy Digital Downloads Braintree requires WordPress 4.2 or higher in order to function properly.', 'edd_fes' ) ); ?></p>
+	</div>
+	<?php
+}


### PR DESCRIPTION
This commit adds 3 new functions for checking the versions of WordPress and EDD. It also checks if EDD is activated or not and throws an admin notice if not.